### PR TITLE
fix: party combat drop logic

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1062,10 +1062,7 @@ function manipulateSimResultsDataForDisplay(simResults) {
     return displaySimResults;
 }
 
-function getDropProfit(simResult, playerToDisplay) {
-    let dropRateMultiplier = simResult.dropRateMultiplier[playerToDisplay];
-    let rareFindMultiplier = simResult.rareFindMultiplier[playerToDisplay];
-    let numberOfPlayers = simResult.numberOfPlayers;
+function calcDropMaps(simResult, dropRateMultiplier, rareFindMultiplier, numberOfPlayers) {
     let monsters = Object.keys(simResult.deaths)
         .filter(enemy => enemy !== "player1" && enemy !== "player2" && enemy !== "player3" && enemy !== "player4" && enemy !== "player5")
         .sort();
@@ -1114,14 +1111,14 @@ function getDropProfit(simResult, playerToDisplay) {
             for (let i = 0; i < simResult.deaths[monster]; i++) {
                 for (let dropObject of dropMap.values()) {
                     let chance = Math.random();
-                    if (chance <= dropObject.dropRate) {
+                    if (chance <= dropObject.dropRate  / numberOfPlayers) {
                         let amount = Math.floor(Math.random() * (dropObject.dropMax - dropObject.dropMin + 1) + dropObject.dropMin)
                         dropObject.number = dropObject.number + amount;
                     }
                 }
                 for (let dropObject of rareDropMap.values()) {
                     let chance = Math.random();
-                    if (chance <= dropObject.dropRate) {
+                    if (chance <= dropObject.dropRate  / numberOfPlayers) {
                         let amount = Math.floor(Math.random() * (dropObject.dropMax - dropObject.dropMin + 1) + dropObject.dropMin)
                         dropObject.number = dropObject.number + amount;
                     }
@@ -1154,10 +1151,16 @@ function getDropProfit(simResult, playerToDisplay) {
         }
     }
 
-    // 在计算完所有掉落后，将总掉落分配给每个玩家
-    for (let [name, totalAmount] of totalDropMap.entries()) {
-        totalDropMap.set(name, Math.round(totalAmount / numberOfPlayers));
-    }
+    return {totalDropMap, noRngTotalDropMap};
+}
+
+
+function getDropProfit(simResult, playerToDisplay) {
+    let dropRateMultiplier = simResult.dropRateMultiplier[playerToDisplay];
+    let rareFindMultiplier = simResult.rareFindMultiplier[playerToDisplay];
+    let numberOfPlayers = simResult.numberOfPlayers;
+
+    let {totalDropMap, noRngTotalDropMap} = calcDropMaps(simResult, dropRateMultiplier, rareFindMultiplier, numberOfPlayers);
 
     let noRngTotal = 0;
     for (let [name, dropAmount] of noRngTotalDropMap.entries()) {
@@ -1388,103 +1391,19 @@ function showKills(simResult, playerToDisplay) {
 
     let monsters = Object.keys(simResult.deaths)
         .filter(enemy => enemy !== "player1" && enemy !== "player2" && enemy !== "player3" && enemy !== "player4" && enemy !== "player5")
-        .sort();
+        .sort()
+        .forEach(monster => {
+            let killsPerHour = (simResult.deaths[monster] / hoursSimulated).toFixed(1);
+            let monsterRow = createRow(
+                ["col-md-6", "col-md-6 text-end"],
+                [combatMonsterDetailMap[monster].name, killsPerHour]
+            );
+            monsterRow.firstElementChild.setAttribute("data-i18n", "monsterNames." + monster);
+            newChildren.push(monsterRow);
+        });
 
-    const totalDropMap = new Map();
-    const noRngTotalDropMap = new Map();
-    for (const monster of monsters) {
-        let killsPerHour = (simResult.deaths[monster] / hoursSimulated).toFixed(1);
-        let monsterRow = createRow(
-            ["col-md-6", "col-md-6 text-end"],
-            [combatMonsterDetailMap[monster].name, killsPerHour]
-        );
-        monsterRow.firstElementChild.setAttribute("data-i18n", "monsterNames." + monster);
-        newChildren.push(monsterRow);
 
-        const dropMap = new Map();
-        const rareDropMap = new Map();
-        if (combatMonsterDetailMap[monster].dropTable)
-            for (const drop of combatMonsterDetailMap[monster].dropTable) {
-                if (drop.minEliteTier > simResult.eliteTier) {
-                    continue;
-                }
-                const existingDrop = dropMap.get(drop.itemHrid);
-                if (existingDrop) {
-                    existingDrop.dropRate = Math.min(1, existingDrop.dropRate + drop.dropRate * dropRateMultiplier);
-                    existingDrop.dropMin = Math.max(existingDrop.dropMin, drop.minCount);
-                    existingDrop.dropMax = Math.max(existingDrop.dropMax, drop.maxCount);
-                } else {
-                    dropMap.set(drop.itemHrid, { "dropRate": Math.min(1, drop.dropRate * dropRateMultiplier), "number": 0, "dropMin": drop.minCount, "dropMax": drop.maxCount, "noRngDropAmount": 0 });
-                }
-            }
-        if (combatMonsterDetailMap[monster].rareDropTable)
-            for (const drop of combatMonsterDetailMap[monster].rareDropTable) {
-                if (drop.minEliteTier > simResult.eliteTier) {
-                    continue;
-                }
-                const existingRareDrop = rareDropMap.get(drop.itemHrid);
-                if (existingRareDrop) {
-                    existingRareDrop.dropRate = Math.min(1, existingRareDrop.dropRate + drop.dropRate * rareFindMultiplier);
-                    existingRareDrop.dropMin = Math.max(existingRareDrop.dropMin, drop.minCount);
-                    existingRareDrop.dropMax = Math.max(existingRareDrop.dropMax, drop.maxCount);
-                } else {
-                    rareDropMap.set(drop.itemHrid, { "dropRate": drop.dropRate * rareFindMultiplier, "number": 0, "dropMin": drop.minCount, "dropMax": drop.maxCount, "noRngDropAmount": 0 });
-                }
-            }
-
-        for (let dropObject of dropMap.values()) {
-            dropObject.noRngDropAmount += simResult.deaths[monster] * dropObject.dropRate * ((dropObject.dropMax + dropObject.dropMin) / 2) / numberOfPlayers;
-        }
-        for (let dropObject of rareDropMap.values()) {
-            dropObject.noRngDropAmount += simResult.deaths[monster] * dropObject.dropRate * ((dropObject.dropMax + dropObject.dropMin) / 2) / numberOfPlayers;
-        }
-
-        for (let i = 0; i < simResult.deaths[monster]; i++) {
-            for (let dropObject of dropMap.values()) {
-                let chance = Math.random();
-                if (chance <= dropObject.dropRate) {
-                    let amount = Math.floor(Math.random() * (dropObject.dropMax - dropObject.dropMin + 1) + dropObject.dropMin)
-                    dropObject.number = dropObject.number + amount;
-                }
-            }
-            for (let dropObject of rareDropMap.values()) {
-                let chance = Math.random();
-                if (chance <= dropObject.dropRate) {
-                    let amount = Math.floor(Math.random() * (dropObject.dropMax - dropObject.dropMin + 1) + dropObject.dropMin)
-                    dropObject.number = dropObject.number + amount;
-                }
-            }
-        }
-        for (let [name, dropObject] of dropMap.entries()) {
-            if (totalDropMap.has(name)) {
-                totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
-            } else {
-                totalDropMap.set(name, dropObject.number);
-            }
-            if (noRngTotalDropMap.has(name)) {
-                noRngTotalDropMap.set(name, noRngTotalDropMap.get(name) + dropObject.noRngDropAmount);
-            } else {
-                noRngTotalDropMap.set(name, dropObject.noRngDropAmount);
-            }
-        }
-        for (let [name, dropObject] of rareDropMap.entries()) {
-            if (totalDropMap.has(name)) {
-                totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
-            } else {
-                totalDropMap.set(name, dropObject.number);
-            }
-            if (noRngTotalDropMap.has(name)) {
-                noRngTotalDropMap.set(name, noRngTotalDropMap.get(name) + dropObject.noRngDropAmount);
-            } else {
-                noRngTotalDropMap.set(name, dropObject.noRngDropAmount);
-            }
-        }
-    }
-
-    // 在计算完所有掉落后，将总掉落分配给每个玩家
-    for (let [name, totalAmount] of totalDropMap.entries()) {
-        totalDropMap.set(name, Math.round(totalAmount / numberOfPlayers));
-    }
+    let {totalDropMap, noRngTotalDropMap} = calcDropMaps(simResult, dropRateMultiplier, rareFindMultiplier, numberOfPlayers);
 
     let revenueModalTable = document.querySelector("#revenueTable > tbody");
     let total = 0;

--- a/src/main.js
+++ b/src/main.js
@@ -1129,9 +1129,9 @@ function getDropProfit(simResult, playerToDisplay) {
             }
             for (let [name, dropObject] of dropMap.entries()) {
                 if (totalDropMap.has(name)) {
-                    totalDropMap.set(name, Math.round((totalDropMap.get(name) + dropObject.number) / numberOfPlayers));
+                    totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
                 } else {
-                    totalDropMap.set(name, Math.round(dropObject.number / numberOfPlayers));
+                    totalDropMap.set(name, dropObject.number);
                 }
                 if (noRngTotalDropMap.has(name)) {
                     noRngTotalDropMap.set(name, noRngTotalDropMap.get(name) + dropObject.noRngDropAmount);
@@ -1152,6 +1152,11 @@ function getDropProfit(simResult, playerToDisplay) {
                 }
             }
         }
+    }
+
+    // 在计算完所有掉落后，将总掉落分配给每个玩家
+    for (let [name, totalAmount] of totalDropMap.entries()) {
+        totalDropMap.set(name, Math.round(totalAmount / numberOfPlayers));
     }
 
     let noRngTotal = 0;
@@ -1452,9 +1457,9 @@ function showKills(simResult, playerToDisplay) {
         }
         for (let [name, dropObject] of dropMap.entries()) {
             if (totalDropMap.has(name)) {
-                totalDropMap.set(name, Math.round((totalDropMap.get(name) + dropObject.number) / numberOfPlayers));
+                totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
             } else {
-                totalDropMap.set(name, Math.round(dropObject.number / numberOfPlayers));
+                totalDropMap.set(name, dropObject.number);
             }
             if (noRngTotalDropMap.has(name)) {
                 noRngTotalDropMap.set(name, noRngTotalDropMap.get(name) + dropObject.noRngDropAmount);
@@ -1474,6 +1479,11 @@ function showKills(simResult, playerToDisplay) {
                 noRngTotalDropMap.set(name, dropObject.noRngDropAmount);
             }
         }
+    }
+
+    // 在计算完所有掉落后，将总掉落分配给每个玩家
+    for (let [name, totalAmount] of totalDropMap.entries()) {
+        totalDropMap.set(name, Math.round(totalAmount / numberOfPlayers));
     }
 
     let revenueModalTable = document.querySelector("#revenueTable > tbody");


### PR DESCRIPTION
# 组队战斗掉落分配修复补丁 / Party Combat Drop Distribution Fix Patch

## 问题描述 / Problem Description

在MWI战斗模拟器中发现了组队战斗时掉落分配的严重逻辑错误，导致以下问题：

A critical logical error was discovered in the party combat drop distribution system of the MWI Combat Simulator, causing the following issues:

### 现象 / Symptoms
- **单人战斗 / Solo Combat**：哥布林星球24小时模拟，击杀92/小时，掉落6500个哥布林皮 / Goblin Planet 24h simulation: 92 kills/hour, 6500 goblin hide drops
- **三人组队 / 3-Player Party**：哥布林星球24小时模拟，击杀120/小时，每人仅掉落700个哥布林皮 / Goblin Planet 24h simulation: 120 kills/hour, only 700 goblin hide drops per player

### 理论vs实际 / Theory vs Reality
- **理论计算 / Theoretical**：三人组队击杀更多，总掉落应超过单人 / 3-player party kills more enemies, total drops should exceed solo
- **实际结果 / Actual Result**：三人组队总掉落(2100)远小于单人掉落(6500) / 3-player party total drops (2100) far less than solo drops (6500)

## 根本原因 / Root Cause

### 错误的掉落分配逻辑 / Incorrect Drop Distribution Logic
在 `getDropProfit` 和 `showKills` 函数中，掉落分配使用了错误的数学逻辑：

The `getDropProfit` and `showKills` functions used incorrect mathematical logic for drop distribution:

```javascript
// 错误的原始代码 / Incorrect original code
if (totalDropMap.has(name)) {
    totalDropMap.set(name, Math.round((totalDropMap.get(name) + dropObject.number) / numberOfPlayers));
} else {
    totalDropMap.set(name, Math.round(dropObject.number / numberOfPlayers));
}
```

### 问题分析 / Problem Analysis
这种逻辑导致每次新的掉落都会与之前已经被稀释的数量重新计算，造成：

This logic caused each new drop to be recalculated with previously diluted amounts, resulting in:
- 单人战斗 / Solo Combat：`dropAmount / 1 = dropAmount` ✅ 正确 / Correct
- 三人组队 / 3-Player Party：重复除法导致掉落被严重低估 / Repeated division causes severe underestimation ❌ 错误 / Incorrect

**示例计算过程（3个怪物，每个掉1个物品）/ Example Calculation Process (3 monsters, 1 drop each)：**
1. 第一个怪物 / First monster：`1 / 3 = 0.33`
2. 第二个怪物 / Second monster：`(0.33 + 1) / 3 = 0.44`
3. 第三个怪物 / Third monster：`(0.44 + 1) / 3 = 0.48`

结果：每人0.48个，而不是正确的1个！/ Result: 0.48 per player instead of the correct 1 item!

## 修复方案 / Fix Solution

### 修复策略 / Fix Strategy
1. **分离累加和分配逻辑 / Separate Accumulation and Distribution Logic**：先累加所有掉落，再统一分配 / First accumulate all drops, then distribute uniformly
2. **统一处理普通和稀有掉落 / Unified Handling of Normal and Rare Drops**：确保逻辑一致性 / Ensure logical consistency
3. **在两个函数中应用相同修复 / Apply Same Fix to Both Functions**：`getDropProfit` 和 `showKills`

### 修复后的逻辑 / Fixed Logic
```javascript
// 步骤1：累加所有掉落（不除以玩家数）
// Step 1: Accumulate all drops (without dividing by player count)
for (let [name, dropObject] of dropMap.entries()) {
    if (totalDropMap.has(name)) {
        totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
    } else {
        totalDropMap.set(name, dropObject.number);
    }
}

// 步骤2：在所有计算完成后统一分配
// Step 2: Distribute uniformly after all calculations are complete
for (let [name, totalAmount] of totalDropMap.entries()) {
    totalDropMap.set(name, Math.round(totalAmount / numberOfPlayers));
}
```

## 代码变更 / Code Changes

### 文件 / File：src/main.js

#### 修改1：getDropProfit函数 (约第1130-1141行) / Change 1: getDropProfit function (around lines 1130-1141)
```diff
  for (let [name, dropObject] of dropMap.entries()) {
      if (totalDropMap.has(name)) {
-         totalDropMap.set(name, Math.round((totalDropMap.get(name) + dropObject.number) / numberOfPlayers));
+         totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
      } else {
-         totalDropMap.set(name, Math.round(dropObject.number / numberOfPlayers));
+         totalDropMap.set(name, dropObject.number);
      }
      // ... 其他逻辑保持不变 / ... other logic remains unchanged
  }
```

#### 修改2：getDropProfit函数中稀有掉落处理 (约第1149-1160行) / Change 2: Rare drop handling in getDropProfit function (around lines 1149-1160)
```diff
  for (let [name, dropObject] of rareDropMap.entries()) {
      if (totalDropMap.has(name)) {
-         // 原代码没有除以numberOfPlayers，但这是另一个bug
+         totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
      } else {
+         totalDropMap.set(name, dropObject.number);
      }
      // ... 其他逻辑保持不变 / ... other logic remains unchanged
  }
```

#### 修改3：getDropProfit函数新增统一分配逻辑 (约第1164行) / Change 3: Added unified distribution logic to getDropProfit function (around line 1164)
```diff
  }
+ 
+ // 在计算完所有掉落后，将总掉落分配给每个玩家
+ // After calculating all drops, distribute total drops to each player
+ for (let [name, totalAmount] of totalDropMap.entries()) {
+     totalDropMap.set(name, Math.round(totalAmount / numberOfPlayers));
+ }

  let noRngTotal = 0;
```

#### 修改4：showKills函数 (约第1460-1470行) / Change 4: showKills function (around lines 1460-1470)
```diff
  for (let [name, dropObject] of dropMap.entries()) {
      if (totalDropMap.has(name)) {
-         totalDropMap.set(name, Math.round((totalDropMap.get(name) + dropObject.number) / numberOfPlayers));
+         totalDropMap.set(name, totalDropMap.get(name) + dropObject.number);
      } else {
-         totalDropMap.set(name, Math.round(dropObject.number / numberOfPlayers));
+         totalDropMap.set(name, dropObject.number);
      }
  }
```

#### 修改5：showKills函数新增统一分配逻辑 (约第1485行) / Change 5: Added unified distribution logic to showKills function (around line 1485)
```diff
  }
+ 
+ // 在计算完所有掉落后，将总掉落分配给每个玩家
+ // After calculating all drops, distribute total drops to each player
+ for (let [name, totalAmount] of totalDropMap.entries()) {
+     totalDropMap.set(name, Math.round(totalAmount / numberOfPlayers));
+ }

  let revenueModalTable = document.querySelector("#revenueTable > tbody");
```